### PR TITLE
Pna65 issue request flow tests

### DIFF
--- a/cordapp/contracts/src/main/java/com/newamerica/contracts/FundContract.java
+++ b/cordapp/contracts/src/main/java/com/newamerica/contracts/FundContract.java
@@ -54,7 +54,7 @@ public class FundContract implements Contract {
 
                 // combine the Lists
                 List<AbstractParty> combinedLists = Stream.concat(outputState.owners.stream(), outputState.requiredSigners.stream()) .collect(Collectors.toList());
-                require.using("All owners and requiredSigners must be in the participant List." +  outputState.getParticipants(), outputState.getParticipants().containsAll(combinedLists));
+                require.using("All owners and requiredSigners must be in the participant List.", outputState.getParticipants().containsAll(combinedLists));
                 return null;
             });
         }else if(commandData.equals(new Commands.Withdraw())){

--- a/cordapp/contracts/src/main/java/com/newamerica/contracts/FundContract.java
+++ b/cordapp/contracts/src/main/java/com/newamerica/contracts/FundContract.java
@@ -54,7 +54,7 @@ public class FundContract implements Contract {
 
                 // combine the Lists
                 List<AbstractParty> combinedLists = Stream.concat(outputState.owners.stream(), outputState.requiredSigners.stream()) .collect(Collectors.toList());
-                require.using("All owners and requiredSigners must be in the participant List.", outputState.participants.containsAll(combinedLists));
+                require.using("All owners and requiredSigners must be in the participant List." +  outputState.getParticipants(), outputState.getParticipants().containsAll(combinedLists));
                 return null;
             });
         }else if(commandData.equals(new Commands.Withdraw())){

--- a/cordapp/contracts/src/main/java/com/newamerica/contracts/RequestContract.java
+++ b/cordapp/contracts/src/main/java/com/newamerica/contracts/RequestContract.java
@@ -8,10 +8,6 @@ import net.corda.core.contracts.TypeOnlyCommandData;
 import net.corda.core.transactions.LedgerTransaction;
 import org.jetbrains.annotations.NotNull;
 
-import java.security.PublicKey;
-import java.util.HashSet;
-import java.util.stream.Collectors;
-
 import static net.corda.core.contracts.ContractsDSL.requireSingleCommand;
 import static net.corda.core.contracts.ContractsDSL.requireThat;
 

--- a/cordapp/contracts/src/main/java/com/newamerica/contracts/RequestContract.java
+++ b/cordapp/contracts/src/main/java/com/newamerica/contracts/RequestContract.java
@@ -8,6 +8,10 @@ import net.corda.core.contracts.TypeOnlyCommandData;
 import net.corda.core.transactions.LedgerTransaction;
 import org.jetbrains.annotations.NotNull;
 
+import java.security.PublicKey;
+import java.util.HashSet;
+import java.util.stream.Collectors;
+
 import static net.corda.core.contracts.ContractsDSL.requireSingleCommand;
 import static net.corda.core.contracts.ContractsDSL.requireThat;
 

--- a/cordapp/contracts/src/main/java/com/newamerica/states/RequestState.java
+++ b/cordapp/contracts/src/main/java/com/newamerica/states/RequestState.java
@@ -122,6 +122,22 @@ public class RequestState implements LinearState {
         );
     }
 
+    public RequestState updateParticipantList(List<AbstractParty> participantList){
+        return new RequestState(
+                this.authorizedUserUsername,
+                this.authorizedUserDept,
+                this.authorizerUserUsername,
+                this.authorizerDept,
+                this.externalAccountId,
+                this.amount,
+                this.currency,
+                this.datetime,
+                this.status,
+                this.fundStateLinearId,
+                participantList
+        );
+    }
+
     @CordaSerializable
     public enum RequestStateStatus {
         PENDING("PENDING"),

--- a/cordapp/contracts/src/test/java/com/newamerica/state/TransferStateTests.java
+++ b/cordapp/contracts/src/test/java/com/newamerica/state/TransferStateTests.java
@@ -17,8 +17,8 @@ import java.util.List;
 import java.util.Locale;
 
 import static com.newamerica.TestUtils.CATANTreasury;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 
 public class TransferStateTests {

--- a/cordapp/workflows/src/main/java/com/newamerica/flows/IssueFundFlow.java
+++ b/cordapp/workflows/src/main/java/com/newamerica/flows/IssueFundFlow.java
@@ -42,7 +42,6 @@ public class IssueFundFlow {
             final Party notary = getPreferredNotary(getServiceHub());
             TransactionBuilder transactionBuilder = new TransactionBuilder(notary);
             CommandData commandData = new FundContract.Commands.Issue();
-//            outputFundState.getParticipants().add(getOurIdentity());
             transactionBuilder.addCommand(commandData, outputFundState.getParticipants().stream().map(AbstractParty::getOwningKey).collect(Collectors.toList()));
             transactionBuilder.addOutputState(outputFundState, FundContract.ID);
             transactionBuilder.verify(getServiceHub());

--- a/cordapp/workflows/src/main/java/com/newamerica/flows/IssueFundFlow.java
+++ b/cordapp/workflows/src/main/java/com/newamerica/flows/IssueFundFlow.java
@@ -42,7 +42,7 @@ public class IssueFundFlow {
             final Party notary = getPreferredNotary(getServiceHub());
             TransactionBuilder transactionBuilder = new TransactionBuilder(notary);
             CommandData commandData = new FundContract.Commands.Issue();
-            outputFundState.getParticipants().add(getOurIdentity());
+//            outputFundState.getParticipants().add(getOurIdentity());
             transactionBuilder.addCommand(commandData, outputFundState.getParticipants().stream().map(AbstractParty::getOwningKey).collect(Collectors.toList()));
             transactionBuilder.addOutputState(outputFundState, FundContract.ID);
             transactionBuilder.verify(getServiceHub());

--- a/cordapp/workflows/src/main/java/com/newamerica/flows/IssueRequestFlow.java
+++ b/cordapp/workflows/src/main/java/com/newamerica/flows/IssueRequestFlow.java
@@ -17,6 +17,7 @@ import net.corda.core.node.services.vault.QueryCriteria;
 import net.corda.core.transactions.SignedTransaction;
 import net.corda.core.transactions.TransactionBuilder;
 import net.corda.core.utilities.ProgressTracker;
+import org.jetbrains.annotations.NotNull;
 
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
@@ -40,19 +41,19 @@ public class IssueRequestFlow {
                 String authorizedUserDept,
                 String authorizerUserUsername,
                 Party authorizerDept,
-                String externalAcountId,
+                String externalAccountId,
                 BigDecimal amount,
                 Currency currency,
                 ZonedDateTime datetime,
                 UniqueIdentifier fundStateLinearId,
                 List<AbstractParty> participants
-        ){
+        ) {
             this.outputRequestState = new RequestState(
                     authorizedUserUsername,
                     authorizedUserDept,
                     authorizerUserUsername,
                     authorizerDept,
-                    externalAcountId,
+                    externalAccountId,
                     amount,
                     currency,
                     datetime,
@@ -73,72 +74,97 @@ public class IssueRequestFlow {
             Vault.Page results = getServiceHub().getVaultService().queryBy(FundState.class, queryCriteria);
             StateAndRef inputStateRef = (StateAndRef) results.getStates().get(0);
             FundState inputStateRefFundState = (FundState) inputStateRef.getState().getData();
-            if (outputRequestState.amount.compareTo(inputStateRefFundState.maxWithdrawalAmount) > 0){
+            if (outputRequestState.amount.compareTo(inputStateRefFundState.maxWithdrawalAmount) > 0) {
                 outputRequestState = outputRequestState.changeStatus(RequestState.RequestStateStatus.FLAGGED);
             }
+            outputRequestState.updateParticipantList(inputStateRefFundState.getParticipants());
 
             final Party notary = getPreferredNotary(getServiceHub());
             TransactionBuilder transactionBuilder = new TransactionBuilder(notary);
             CommandData commandData = new RequestContract.Commands.Issue();
-            outputRequestState.getParticipants().add(getOurIdentity());
-            transactionBuilder.addCommand(commandData, outputRequestState.getParticipants().stream().map(i -> (i.getOwningKey())).collect(Collectors.toList()));
+            transactionBuilder.addCommand(commandData, inputStateRefFundState.getRequiredSigners().stream().map(AbstractParty::getOwningKey).collect(Collectors.toList()));
             transactionBuilder.addOutputState(outputRequestState, RequestContract.ID);
             transactionBuilder.verify(getServiceHub());
 
             //partially sign transaction
             SignedTransaction partSignedTx = getServiceHub().signInitialTransaction(transactionBuilder, getOurIdentity().getOwningKey());
 
+            SignedTransaction stx = subFlow(new CollectSignaturesInitiatingFlow(partSignedTx, inputStateRefFundState.getRequiredSigners()));
+
             //create list of all parties minus ourIdentity for required signatures
-            List<Party> otherParties = inputStateRefFundState.getRequiredSigners().stream().map(i -> ((Party) i)).collect(Collectors.toList());
+            List<Party> otherParties = outputRequestState.getParticipants().stream().map(i -> ((Party) i)).collect(Collectors.toList());
+            otherParties.remove(getOurIdentity());
 
             //create sessions based on otherParties
-            List<FlowSession> flowSessions = otherParties.stream().map(i -> initiateFlow(i)).collect(Collectors.toList());
+            List<FlowSession> otherPartiesFlowSessions = otherParties.stream().map(this::initiateFlow).collect(Collectors.toList());
 
-            SignedTransaction signedTransaction = subFlow(new CollectSignaturesFlow(partSignedTx, flowSessions));
-            return subFlow(new FinalityFlow(signedTransaction, flowSessions));
+            return subFlow(new FinalityFlow(stx, otherPartiesFlowSessions));
+        }
+    }
+
+    // Call receiveFinalityFlow for all participants
+    @InitiatedBy(IssueRequestFlow.InitiatorFlow.class)
+    public static class ExtraInitiatingFlowResponder extends FlowLogic<SignedTransaction> {
+        private FlowSession session;
+        public ExtraInitiatingFlowResponder(
+                FlowSession session
+        ){
+            this.session = session;
         }
 
-        /**
-         * This is the flow which signs RequestState issuances.
-         */
+        @Suspendable
+        @Override
+        public SignedTransaction call() throws FlowException {
+            // save the transaction and nothing else
+            return subFlow(new ReceiveFinalityFlow(session));
+        }
+    }
 
-        @InitiatedBy(IssueRequestFlow.InitiatorFlow.class)
-        public static class ResponderFlow extends FlowLogic<SignedTransaction>{
-            private final FlowSession flowSession;
-            private SecureHash txWeJustSigned;
+    // Collected the signatures of only the requiredSigners listed on the FundState
+    @InitiatingFlow
+    @StartableByRPC
+    public static class CollectSignaturesInitiatingFlow extends FlowLogic<SignedTransaction> {
 
-            public ResponderFlow(FlowSession flowSession){
-                this.flowSession = flowSession;
-            }
+        private SignedTransaction transaction;
+        private List<AbstractParty> requiredSigners;
 
-            @Suspendable
-            @Override
-            public SignedTransaction call() throws FlowException {
-                class SignTxFlow extends SignTransactionFlow{
+        public CollectSignaturesInitiatingFlow(
+                SignedTransaction transaction,
+                List<AbstractParty> requiredSigners
+        ) {
+            this.transaction = transaction;
+            this.requiredSigners = requiredSigners;
+        }
 
-                    private SignTxFlow(FlowSession flowSession, ProgressTracker progressTracker){
-                        super(flowSession, progressTracker);
-                    }
+        @Suspendable
+        @Override
+        public SignedTransaction call() throws FlowException {
+            // create new sessions to signers and trigger the signing responder flow
+            List<FlowSession> requiredSigsFlowSessions = requiredSigners.stream().map(i -> initiateFlow(i)).collect(Collectors.toList());
+            return subFlow(new CollectSignaturesFlow(transaction, requiredSigsFlowSessions));
+        }
+    }
 
-                    @Override
-                    protected void checkTransaction(SignedTransaction stx){
-                        requireThat(req -> {
-                            ContractState output = stx.getTx().getOutputs().get(0).getData();
-                            req.using("This must be an RequestState transaction", output instanceof RequestState);
-                            return null;
-                        });
-                        txWeJustSigned = stx.getId();
-                    }
+    //create sessions for each of the signers
+    @InitiatedBy(CollectSignaturesInitiatingFlow.class)
+    public static class CollectSignaturesResponder extends FlowLogic<SignedTransaction> {
+        private FlowSession session;
+
+        public CollectSignaturesResponder(
+                FlowSession session
+        ){
+            this.session = session;
+        }
+
+        @Suspendable
+        @Override
+        public SignedTransaction call() throws FlowException {
+            return subFlow(new SignTransactionFlow(session) {
+                @Override
+                protected void checkTransaction(@NotNull SignedTransaction stx) throws FlowException {
+
                 }
-                flowSession.getCounterpartyFlowInfo().getFlowVersion();
-
-                // Create a sign transaction flow
-                SignTxFlow signTxFlow = new SignTxFlow(flowSession, SignTransactionFlow.Companion.tracker());
-
-                // Run the sign transaction flow to sign the transaction
-                subFlow(signTxFlow);
-                return subFlow(new ReceiveFinalityFlow(flowSession, txWeJustSigned));
-            }
+            });
         }
     }
 }

--- a/cordapp/workflows/src/main/java/com/newamerica/flows/IssueRequestFlow.java
+++ b/cordapp/workflows/src/main/java/com/newamerica/flows/IssueRequestFlow.java
@@ -5,10 +5,8 @@ import com.newamerica.contracts.RequestContract;
 import com.newamerica.states.FundState;
 import com.newamerica.states.RequestState;
 import net.corda.core.contracts.CommandData;
-import net.corda.core.contracts.ContractState;
 import net.corda.core.contracts.StateAndRef;
 import net.corda.core.contracts.UniqueIdentifier;
-import net.corda.core.crypto.SecureHash;
 import net.corda.core.flows.*;
 import net.corda.core.identity.AbstractParty;
 import net.corda.core.identity.Party;
@@ -16,7 +14,6 @@ import net.corda.core.node.services.Vault;
 import net.corda.core.node.services.vault.QueryCriteria;
 import net.corda.core.transactions.SignedTransaction;
 import net.corda.core.transactions.TransactionBuilder;
-import net.corda.core.utilities.ProgressTracker;
 import org.jetbrains.annotations.NotNull;
 
 import java.math.BigDecimal;
@@ -28,7 +25,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static com.newamerica.flows.CordappConfigUtilities.getPreferredNotary;
-import static net.corda.core.contracts.ContractsDSL.requireThat;
 
 public class IssueRequestFlow {
     @InitiatingFlow

--- a/cordapp/workflows/src/test/java/com/newamerica/flow/IssueRequestFlowTests.java
+++ b/cordapp/workflows/src/test/java/com/newamerica/flow/IssueRequestFlowTests.java
@@ -68,8 +68,6 @@ public class IssueRequestFlowTests {
 
         // For real nodes this happens automatically, but we have to manually register the flow for tests
         startedNodes.forEach(el -> el.registerInitiatedFlow(IssueFundFlow.ResponderFlow.class));
-//        startedNodes.forEach(el -> el.registerInitiatedFlow(IssueRequestFlow.CollectSignaturesInitiatingFlow.class));
-//        startedNodes.forEach(el -> el.registerInitiatedFlow(IssueRequestFlow.InitiatorFlow.class));
         startedNodes.forEach(el -> el.registerInitiatedFlow(IssueRequestFlow.ExtraInitiatingFlowResponder.class));
         startedNodes.forEach(el -> el.registerInitiatedFlow(IssueRequestFlow.CollectSignaturesResponder.class));
 
@@ -82,13 +80,6 @@ public class IssueRequestFlowTests {
         usCSO = e.getInfo().getLegalIdentitiesAndCerts().get(0).getParty();
         catanCSO = f.getInfo().getLegalIdentitiesAndCerts().get(0).getParty();
 
-//        owners.add(usDos);
-//        requiredSigners.add(usDos);
-//        requiredSigners.add(catanMoj);
-//        participants.add(usDoj);
-//        participants.add(catanMoj);
-//        partialRequestParticipants.add(usCSO);
-//        partialRequestParticipants.add(catanCSO);
         owners.add(usDos);
         requiredSigners.add(usDoj);
         requiredSigners.add(catanMoj);

--- a/cordapp/workflows/src/test/java/com/newamerica/flow/IssueRequestFlowTests.java
+++ b/cordapp/workflows/src/test/java/com/newamerica/flow/IssueRequestFlowTests.java
@@ -1,0 +1,165 @@
+package com.newamerica.flow;
+
+import com.newamerica.contracts.RequestContract;
+import com.newamerica.flows.IssueFundFlow;
+import com.newamerica.flows.IssueRequestFlow;
+import com.newamerica.states.FundState;
+import com.newamerica.states.RequestState;
+import net.corda.core.contracts.Command;
+import net.corda.core.identity.AbstractParty;
+import net.corda.core.identity.CordaX500Name;
+import net.corda.core.identity.Party;
+import net.corda.core.transactions.SignedTransaction;
+import net.corda.testing.node.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.math.BigDecimal;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.*;
+import java.util.concurrent.Future;
+
+public class IssueRequestFlowTests {
+    private MockNetwork mockNetwork;
+    private StartedMockNode a, b, c, d, e, f;
+    private Party usDos;
+    private Party usDoj;
+    private Party usCSO;
+    private Party catanMof;
+    private Party catanMoj;
+    private Party catanCSO;
+    private final List<AbstractParty> owners = new ArrayList<>();
+    private final List<AbstractParty> requiredSigners = new ArrayList<>();
+    private final List<AbstractParty> participants = new ArrayList<>();
+    private final List<AbstractParty> partialRequestParticipants = new ArrayList<>();
+
+
+    @Before
+    public void setup() {
+        Map<String, String> config = new HashMap<>();
+        config.put("notary", "O=Notary,L=London,C=GB");
+        MockNetworkParameters mockNetworkParameters = new MockNetworkParameters().withCordappsForAllNodes(
+                Arrays.asList(
+                        TestCordapp.findCordapp("com.newamerica.contracts"),
+                        TestCordapp.findCordapp("com.newamerica.flows").withConfig(config)
+                )
+        ).withNotarySpecs(Arrays.asList(new MockNetworkNotarySpec(new CordaX500Name("Notary", "London", "GB"))));
+        mockNetwork = new MockNetwork(mockNetworkParameters);
+        System.out.println(mockNetwork);
+
+        a = mockNetwork.createNode(new MockNodeParameters());
+        b = mockNetwork.createNode(new MockNodeParameters());
+        c = mockNetwork.createNode(new MockNodeParameters());
+        d = mockNetwork.createNode(new MockNodeParameters());
+        e = mockNetwork.createNode(new MockNodeParameters());
+        f = mockNetwork.createNode(new MockNodeParameters());
+
+        ArrayList<StartedMockNode> startedNodes = new ArrayList<>();
+        startedNodes.add(a);
+        startedNodes.add(b);
+        startedNodes.add(c);
+        startedNodes.add(d);
+        startedNodes.add(e);
+        startedNodes.add(f);
+
+        // For real nodes this happens automatically, but we have to manually register the flow for tests
+        startedNodes.forEach(el -> el.registerInitiatedFlow(IssueFundFlow.ResponderFlow.class));
+//        startedNodes.forEach(el -> el.registerInitiatedFlow(IssueRequestFlow.CollectSignaturesInitiatingFlow.class));
+//        startedNodes.forEach(el -> el.registerInitiatedFlow(IssueRequestFlow.InitiatorFlow.class));
+        startedNodes.forEach(el -> el.registerInitiatedFlow(IssueRequestFlow.ExtraInitiatingFlowResponder.class));
+        startedNodes.forEach(el -> el.registerInitiatedFlow(IssueRequestFlow.CollectSignaturesResponder.class));
+
+        mockNetwork.runNetwork();
+
+        usDos = a.getInfo().getLegalIdentitiesAndCerts().get(0).getParty();
+        usDoj = b.getInfo().getLegalIdentitiesAndCerts().get(0).getParty();
+        catanMof = c.getInfo().getLegalIdentitiesAndCerts().get(0).getParty();
+        catanMoj = d.getInfo().getLegalIdentitiesAndCerts().get(0).getParty();
+        usCSO = e.getInfo().getLegalIdentitiesAndCerts().get(0).getParty();
+        catanCSO = f.getInfo().getLegalIdentitiesAndCerts().get(0).getParty();
+
+//        owners.add(usDos);
+//        requiredSigners.add(usDos);
+//        requiredSigners.add(catanMoj);
+//        participants.add(usDoj);
+//        participants.add(catanMoj);
+//        partialRequestParticipants.add(usCSO);
+//        partialRequestParticipants.add(catanCSO);
+        owners.add(usDos);
+        requiredSigners.add(usDoj);
+        requiredSigners.add(catanMoj);
+        participants.add(usDos);
+        participants.add(usDoj);
+        participants.add(catanMof);
+        participants.add(catanMoj);
+        partialRequestParticipants.add(usCSO);
+        partialRequestParticipants.add(catanCSO);
+    }
+
+
+    @After
+    public void tearDown() {
+        mockNetwork.stopNodes();
+    }
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    // ensure that properly formed partially signed transactions are returned from the initiator flow
+    @Test
+    public void flowReturnsCorrectlyFormedPartiallySignedTransaction() throws Exception {
+
+        //create FundState
+        IssueFundFlow.InitiatorFlow flow = new IssueFundFlow.InitiatorFlow(
+                usDos,
+                catanMoj,
+                owners,
+                requiredSigners,
+                partialRequestParticipants,
+                BigDecimal.valueOf(5000000),
+                ZonedDateTime.of(2020, 6, 27, 10, 30, 30, 0, ZoneId.of("America/New_York")),
+                BigDecimal.valueOf(1000000),
+                Currency.getInstance(Locale.US),
+                participants
+        );
+
+
+        Future<SignedTransaction> future = a.startFlow(flow);
+        mockNetwork.runNetwork();
+        SignedTransaction stx = future.get();
+        FundState fs = (FundState) stx.getTx().getOutputStates().get(0);
+
+        IssueRequestFlow.InitiatorFlow requestFlow = new IssueRequestFlow.InitiatorFlow(
+                "Alice Bob",
+                "Catan Ministry of Education",
+                "Chris Jones",
+                catanMoj,
+                "1234567890",
+                BigDecimal.valueOf(1000000),
+                Currency.getInstance(Locale.US),
+                ZonedDateTime.of(2020, 6, 27, 10,30,30,0, ZoneId.of("America/New_York")),
+                fs.getLinearId(),
+                participants
+        );
+
+        Future<SignedTransaction> futureTwo = c.startFlow(requestFlow);
+        mockNetwork.runNetwork();
+        SignedTransaction ptx = futureTwo.get();
+
+        // Check the transaction is well formed...
+        // No outputs, one input IOUState and a command with the right properties.
+        assert (ptx.getTx().getInputs().isEmpty());
+        assert (ptx.getTx().getOutputs().get(0).getData() instanceof RequestState);
+
+        Command command = ptx.getTx().getCommands().get(0);
+        assert (command.getValue() instanceof RequestContract.Commands.Issue);
+
+        ptx.verifySignaturesExcept(usDoj.getOwningKey(),
+                mockNetwork.getDefaultNotaryNode().getInfo().getLegalIdentitiesAndCerts().get(0).getOwningKey());
+
+    }
+}


### PR DESCRIPTION
I rebuilt the IssueRequestFlow according to this blog post by Dan:
https://www.corda.net/blog/saving-transactions-where-only-a-subset-of-parties-are-signers/

which explains how to use a subset of participants as signers. The approach I took is explained in the "Separating logic by extra initiating flows" section.